### PR TITLE
Fixed missing redis auth in init.js

### DIFF
--- a/init.js
+++ b/init.js
@@ -203,6 +203,9 @@ var spawnPoolWorkers = function(){
         } else if (!connection) {
             redisConfig = pcfg.redis;
             connection = redis.createClient(redisConfig.port, redisConfig.host);
+            if (portalConfig.redis.password) {
+                connection.auth(portalConfig.redis.password); 
+            }
             connection.on('ready', function(){
                 logger.debug('PPLNT', coin, 'TimeShare processing setup with redis (' + redisConfig.host +
                     ':' + redisConfig.port  + ')');


### PR DESCRIPTION
When Redis is setup with authentication z-nomp-bitcoin-gold fails to start due to a missing line in init.js